### PR TITLE
feat: add VOD download with progress tracking

### DIFF
--- a/core/window.py
+++ b/core/window.py
@@ -111,6 +111,7 @@ class MainWindow(Adw.ApplicationWindow):
         self.subtitle_delay_ms = 0
         self.all_channels_map = {}
         self.active_recorder = None
+        self.active_downloader = None
         self.current_playing_channel_data = None
         self.slider_visibility_determined = False
         self.slider_check_attempts = 0
@@ -568,6 +569,8 @@ class MainWindow(Adw.ApplicationWindow):
         self.detail_view.connect("play-requested", self.on_detail_view_play_requested)
         self.detail_view.connect("back-requested", self.on_detail_view_back_requested)
         self.detail_view.connect("trailer-requested", self.on_trailer_requested)
+        self.detail_view.connect("download-requested", self.on_detail_download_requested)
+        self.detail_view.connect("cancel-download-requested", self.on_detail_cancel_download)
         handler_id = self.bouquet_list.show_locked_button.connect("toggled", self._on_show_locked_toggled)
         self.bouquet_list.show_locked_button.handler_block(handler_id)
         initial_show_locked_state = database.get_show_locked_bouquets_status()
@@ -3391,6 +3394,9 @@ class MainWindow(Adw.ApplicationWindow):
         self._hide_next_episode_prompt()
         if self.active_recorder:
             self.active_recorder.stop()
+        if self.active_downloader:
+            self.active_downloader.stop()
+            self.active_downloader = None
         self.stop_pip()
         self.inhibitor.uninhibit()
         self.subtitle_manager.clear()
@@ -3473,6 +3479,59 @@ class MainWindow(Adw.ApplicationWindow):
         if response_id == "resume":
             start_pos = position
         self._start_playback(url=url, media_type='vod', start_position=start_pos, episode_data=episode_data)
+
+    def on_detail_cancel_download(self, view):
+        if self.active_downloader:
+            threading.Thread(target=self.active_downloader.stop, daemon=True).start()
+            self.active_downloader = None
+        self.detail_view.finish_download_ui()
+        self.show_toast(_("Download cancelled."))
+
+    def on_detail_download_requested(self, view, stream_id_or_path, media_type):
+        title = self.detail_view.current_title or stream_id_or_path
+        safe_title = "".join(c if c.isalnum() or c in " .-_" else "_" for c in title).strip()
+        profile_type = self.profile_data.get('type') if self.profile_data else None
+        if profile_type == 'xtream' and str(stream_id_or_path).isdigit():
+            info_data = xtream_client.get_vod_info(self.profile_data, stream_id_or_path)
+            if not info_data:
+                self.show_toast(_("Error: Could not retrieve movie info."))
+                return
+            movie_data = info_data.get('movie_data', {})
+            final_url = movie_data.get('direct_source')
+            if not final_url:
+                ext = movie_data.get('container_extension', 'mkv')
+                host = self.profile_data.get('host')
+                username = self.profile_data.get('username')
+                password = self.profile_data.get('password')
+                final_url = f"{host}/movie/{username}/{password}/{stream_id_or_path}.{ext}"
+        else:
+            final_url = stream_id_or_path
+            ext = final_url.rsplit('.', 1)[-1] if '.' in final_url.split('/')[-1] else 'mkv'
+            if len(ext) > 4:
+                ext = 'mkv'
+        recordings_dir = database.get_recordings_path()
+        os.makedirs(recordings_dir, exist_ok=True)
+        file_name = f"{safe_title}.mkv"
+        output_path = os.path.join(recordings_dir, file_name)
+        def on_progress(done_bytes, total_bytes):
+            self.detail_view.update_download_progress(done_bytes, total_bytes)
+
+        def on_finished():
+            self.active_downloader = None
+            self.detail_view.finish_download_ui()
+            self.show_toast(_("Download complete: {}").format(file_name))
+            logging.info(f"VOD download finished: {output_path}")
+
+        try:
+            downloader = Recorder(final_url, output_path, on_progress=on_progress, on_finished=on_finished)
+            downloader.start()
+            self.active_downloader = downloader
+            self.detail_view.start_download_ui()
+            self.show_toast(_("Download started: {}").format(file_name))
+            logging.info(f"VOD download started: {output_path}")
+        except Exception as e:
+            logging.error(f"Could not start download: {e}")
+            self.show_toast(_("Error: Could not start download!"))
 
     def on_detail_view_back_requested(self, view):
         active_nav = self.sidebar.list_stack.get_visible_child_name()

--- a/playback/recorder.py
+++ b/playback/recorder.py
@@ -8,29 +8,80 @@ import threading
 from gi.repository import GLib
 
 class Recorder:
-    def __init__(self, stream_url, output_filepath, duration_sec=None):
+    def __init__(self, stream_url, output_filepath, duration_sec=None, on_progress=None, on_finished=None):
         self.stream_url = stream_url
         self.output_filepath = output_filepath
         self.duration_sec = duration_sec
+        self.on_progress = on_progress
+        self.on_finished = on_finished
+        self.total_bytes = 0
         self.process = None
         self.log_thread = None
         self.watchdog_timer = None
         logging.info(f"Recorder (FFmpeg Mode) initialized. URL: {self.stream_url}, Duration: {self.duration_sec}s")
 
     def _log_reader_thread(self):
+        import re
+        dur_re = re.compile(r'Duration:\s*(\d+):(\d+):(\d+\.?\d*)')
+        bit_re = re.compile(r'bitrate:\s*(\d+)\s*kb/s')
+        est_dur = None
+        est_bit = None
         try:
             for line in self.process.stderr:
                 if 'frame=' in line:
-                    logging.debug(f"(FFmpeg Live) {line.strip()}")
+                    logging.debug(f"(FFmpeg) {line.strip()}")
                 else:
-                    logging.info(f"(FFmpeg Live) {line.strip()}")
+                    logging.info(f"(FFmpeg) {line.strip()}")
+                if self.total_bytes == 0 and self.on_progress:
+                    dm = dur_re.search(line)
+                    bm = bit_re.search(line)
+                    if dm:
+                        h, m, s = int(dm.group(1)), int(dm.group(2)), float(dm.group(3))
+                        est_dur = h * 3600 + m * 60 + s
+                    if bm:
+                        est_bit = int(bm.group(1))
+                    if est_dur and est_bit:
+                        self.total_bytes = int(est_dur * est_bit * 1000 / 8)
+                        logging.info(f"Total size estimated from ffmpeg: {self.total_bytes} bytes")
         except Exception as e:
             logging.warning(f"Error in FFmpeg log reader thread: {e}")
+        finally:
+            if self.on_finished and self.process and self.process.poll() == 0:
+                GLib.idle_add(self.on_finished)
+
+    def _progress_monitor_thread(self):
+        import time
+        while self.process and self.process.poll() is None:
+            try:
+                done = os.path.getsize(self.output_filepath)
+                GLib.idle_add(self.on_progress, done, self.total_bytes)
+            except OSError:
+                pass
+            time.sleep(1)
+        # final update after ffmpeg exits
+        try:
+            done = os.path.getsize(self.output_filepath)
+            GLib.idle_add(self.on_progress, done, self.total_bytes)
+        except OSError:
+            pass
 
     def start(self):
         if self.process:
             logging.warning("Attempted to start recording, but a process is already running.")
             return           
+        if self.on_progress:
+            try:
+                import requests
+                r = requests.get(self.stream_url, stream=True, timeout=10, allow_redirects=True,
+                                 headers={'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0'})
+                cl = r.headers.get('Content-Length')
+                r.close()
+                self.total_bytes = int(cl) if cl else 0
+                logging.info(f"Download total size (Content-Length): {self.total_bytes} bytes")
+            except Exception as e:
+                logging.warning(f"Could not get Content-Length: {e}")
+                self.total_bytes = 0
+
         command = [
             'ffmpeg', '-y',
             '-user_agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0',
@@ -60,6 +111,10 @@ class Recorder:
             self.log_thread = threading.Thread(target=self._log_reader_thread)
             self.log_thread.daemon = True
             self.log_thread.start()
+            if self.on_progress:
+                progress_thread = threading.Thread(target=self._progress_monitor_thread)
+                progress_thread.daemon = True
+                progress_thread.start()
             logging.info(f"FFmpeg process started. PID: {self.process.pid}")          
             if self.duration_sec:
                 watchdog_timeout = int(self.duration_sec) + 120

--- a/ui/detail_view.py
+++ b/ui/detail_view.py
@@ -159,7 +159,9 @@ class DetailView(Gtk.Box):
     __gsignals__ = {
         "play-requested": (GObject.SignalFlags.RUN_FIRST, None, (str, str,)),
         "back-requested": (GObject.SignalFlags.RUN_FIRST, None, ()),
-        "trailer-requested": (GObject.SignalFlags.RUN_FIRST, None, (str,))
+        "trailer-requested": (GObject.SignalFlags.RUN_FIRST, None, (str,)),
+        "download-requested": (GObject.SignalFlags.RUN_FIRST, None, (str, str,)),
+        "cancel-download-requested": (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     def __init__(self, **kwargs):
@@ -170,7 +172,9 @@ class DetailView(Gtk.Box):
         self.set_margin_bottom(12)
         self.media_url = None
         self.media_type = None
-        self.current_trailer_key = None       
+        self.current_title = None
+        self.current_trailer_key = None
+        self._is_downloading = False       
         header_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self.append(header_box)
         back_button = Gtk.Button()
@@ -273,13 +277,27 @@ class DetailView(Gtk.Box):
         self.translate_btn.set_child(translate_box)      
         self.translate_btn.connect("clicked", self._on_translate_clicked)
         button_box.append(self.translate_btn)
+        download_row = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, halign=Gtk.Align.CENTER, margin_top=6, spacing=4)
+        self.append(download_row)
+        self.download_button = Gtk.Button(label=_("Download"), icon_name="folder-download-symbolic", css_classes=["pill"])
+        self.download_button.connect("clicked", self._on_download_clicked)
+        download_row.append(self.download_button)
+        self.download_progress_bar = Gtk.ProgressBar()
+        self.download_progress_bar.set_size_request(260, -1)
+        self.download_progress_bar.set_visible(False)
+        download_row.append(self.download_progress_bar)
+        self.download_size_label = Gtk.Label(css_classes=["caption"])
+        self.download_size_label.set_visible(False)
+        download_row.append(self.download_size_label)
 
     def update_content(self, item, media_type):
         logging.info(f"DETAILVIEW: update_content STARTED - Item: {item.props.title}, Type: {media_type}, URL/ID: {item.props.path_or_url}")
         self.media_url = item.props.path_or_url
         self.media_type = media_type
+        self.current_title = item.props.title or ""
         self.current_trailer_key = None
         self.trailer_button.set_sensitive(False)
+        self.download_button.set_visible(media_type in ('vod', 'media'))
         logging.debug("DETAILVIEW: Clearing UI and setting initial info...")
         self.poster_image.set_paintable(None)
         initial_title = item.props.title or ""
@@ -687,6 +705,40 @@ class DetailView(Gtk.Box):
         buffer = self.overview_textview.get_buffer()
         buffer.delete(buffer.get_start_iter(), buffer.get_end_iter())
         buffer.insert(buffer.get_start_iter(), text)
+
+    def _on_download_clicked(self, button):
+        if self._is_downloading:
+            self.emit("cancel-download-requested")
+        elif self.media_url and self.media_type:
+            self.emit("download-requested", self.media_url, self.media_type)
+
+    def start_download_ui(self):
+        self._is_downloading = True
+        self.download_button.set_sensitive(True)
+        self.download_button.set_label(_("Cancel"))
+        self.download_progress_bar.set_fraction(0)
+        self.download_progress_bar.set_visible(True)
+        self.download_size_label.set_text("")
+        self.download_size_label.set_visible(True)
+
+    def update_download_progress(self, done_bytes, total_bytes):
+        if total_bytes > 0:
+            fraction = min(done_bytes / total_bytes, 1.0)
+            self.download_progress_bar.set_fraction(fraction)
+            done_mb = done_bytes / 1048576
+            total_mb = total_bytes / 1048576
+            self.download_size_label.set_text(f"{done_mb:.1f} / {total_mb:.1f} MB  ({int(fraction * 100)}%)")
+        else:
+            self.download_progress_bar.pulse()
+            done_mb = done_bytes / 1048576
+            self.download_size_label.set_text(f"{done_mb:.1f} MB")
+
+    def finish_download_ui(self):
+        self._is_downloading = False
+        self.download_button.set_sensitive(True)
+        self.download_button.set_label(_("Download"))
+        self.download_progress_bar.set_visible(False)
+        self.download_size_label.set_visible(False)
 
     def _on_play_clicked(self, button):
         if self.media_url and self.media_type:


### PR DESCRIPTION
## Summary

- Adds a **Download** button to the VOD detail view (visible only for `vod`/`media` type)
- Tracks download progress by polling the output file size every second
- Fetches total file size via HTTP `GET stream=True`; falls back to estimating from ffmpeg's `Duration` + `bitrate` output
- Shows a progress bar with `X.X / Y.Y MB (Z%)` label while downloading
- Clicking the button again while downloading **cancels** the download (button label switches to "Cancel")
- Stops any active download automatically when the window is closed

## Implementation

- `playback/recorder.py` — added `on_progress` / `on_finished` callbacks, Content-Length fetch, file-size polling thread, ffmpeg output parsing for size estimation
- `ui/detail_view.py` — added Download button, progress bar, size label, and `start/update/finish_download_ui()` methods
- `core/window.py` — connected signals, built VOD URL (same logic as playback), wired progress/cancel/close handlers

## Test plan

- [ ] Open a VOD detail page → Download button appears below Play/Trailer/Translate row
- [ ] Click Download → button changes to "Cancel", progress bar and MB label appear
- [ ] Progress bar advances as file downloads (percentage shown when server returns Content-Length or ffmpeg reports duration)
- [ ] Click Cancel → download stops, UI resets
- [ ] Close window during download → ffmpeg process is terminated

🤖 Generated with [Claude Code](https://claude.ai/claude-code)